### PR TITLE
Return the condition instead of :error

### DIFF
--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -506,14 +506,13 @@ assertion.")
       (incf (fail results) fail)
       (push test-name (failed-tests results)))
     ;; Count errors and record name
-    (when (eq :error exerr)
+    (when exerr
       (incf (exerr results))
       (push test-name (error-tests results)))
     ;; Print a summary of the results
     (when (or *print-summary* *print-failures* *print-errors*)
       (print-summary
-       test-name pass fail
-       (when (eq :error exerr) 1)))))
+       test-name pass fail (when exerr 1)))))
 
 (defun summarize-results (results)
   "Print a summary of all results."
@@ -543,7 +542,7 @@ assertion.")
                   (if (use-debugger-p condition)
                       condition
                       (return-from run-test-thunk
-                        (values *pass* *fail* :error condition))))))
+                        (values *pass* *fail* condition))))))
       (run-code code))
     ;; Return the result count
     (values *pass* *fail* nil)))


### PR DESCRIPTION
Let's just return the condition instead of the `:error` keyword. This patch contains the changes necessary for that change.

On a side note, let's do pull requests on branches other than master so that there is a lower possibility of screwing up another Quicklisp release.
