### PR TITLE
fix typo invoking nonexistent function in with-assertion-debugging-context

### DIFF
--- a/asserts.lisp
+++ b/asserts.lisp
@@ -266,5 +266,5 @@ vice versa."
 
 (defmacro with-failure-debugging (() &body body)
   "A context macro that invokes the debugger on failed assertions"
-  `(with-assertion-debugging-context (lambda () ,@body)))
+  `(with-failure-debugging-context (lambda () ,@body)))
 


### PR DESCRIPTION
This convenience macro expanded into the wrong function name.