### PR TITLE
Fix defpackage forms for CLISP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: common-lisp
+
+env:
+  matrix:
+    - LISP=abcl
+    - LISP=allegro
+    - LISP=sbcl
+    - LISP=sbcl32
+    - LISP=ccl
+    - LISP=ccl32
+    - LISP=clisp
+    - LISP=clisp32
+#    - LISP=cmucl
+    - LISP=ecl
+
+install:
+  - if [ -x ./install.sh ] && head -2 ./install.sh | grep '^# cl-travis' > /dev/null;
+    then
+      ./install.sh;
+    else
+      curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | sh;
+    fi
+
+script:
+  - cl -e '(in-package :cl-user)'
+       -e '(ql:quickload :lisp-unit2)'
+       -e '(let ((*debugger-hook*
+                  (lambda (c h)
+                    (declare (ignore c h))
+                    (uiop:quit -1))))
+             (lisp-unit2:with-failure-debugging-context
+                 (lambda ()
+                   (asdf:perform (quote asdf:test-op) (asdf:find-system :lisp-unit2)))))'

--- a/packages.lisp
+++ b/packages.lisp
@@ -1,9 +1,10 @@
 (in-package :cl-user)
 
+ ;; clisp requires `defpackage`s to be treated as top-level forms
 (#+clisp progn
  
  #-clisp handler-bind
-         ;; fixes sbcl SUPER warnings that prevent automatic fasl loading
+ ;; fixes sbcl SUPER warnings that prevent automatic fasl loading
  #-clisp ((warning (lambda (c)
                      (format *error-output* "~A~%~S" c c)
                      (muffle-warning c))))

--- a/packages.lisp
+++ b/packages.lisp
@@ -1,10 +1,12 @@
 (in-package :cl-user)
 
-(handler-bind
-    ;; fixes sbcl SUPER warnings that prevent automatic fasl loading
-    ((warning (lambda (c)
-                (format *error-output* "~A~%~S" c c)
-                (muffle-warning c))))
+(#+clisp progn
+ 
+ #-clisp handler-bind
+         ;; fixes sbcl SUPER warnings that prevent automatic fasl loading
+ #-clisp ((warning (lambda (c)
+                     (format *error-output* "~A~%~S" c c)
+                     (muffle-warning c))))
   (defpackage :lisp-unit2
     (:use :common-lisp :iter)
     ;; Print parameters


### PR DESCRIPTION
This repository fails to compile on CLISP because the `defpackage` forms are not top-level, and so the `:lisp-unit2` package isn't visible to the form defining `:lisp-unit2-asserts`. Conditionally reading the form as a `progn` instead of `handler-bind` will fix this. (I also tried taking out the `handler-bind` completely and didn't run into any problems on SBCL, so if the original reason for that form no longer applies I guess you could just leave it out.)

Failing and passing CLISP builds for reference:
https://travis-ci.org/DalekBaldwin/lisp-unit2/builds/46448336
https://travis-ci.org/DalekBaldwin/lisp-unit2/builds/46448727