### PR TITLE
The *dubug-hook* doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ while maintaining its benefits and workflow
 ;; tests are running or after all the tests have run
 
 ;; to disable the debugger:
-(let (*debug-hook*)
+(let (*debugger-hook*)
   (run-tests :tests 'my-tests::test-subtraction))
 
 ;; to debug failed assertions with the context function


### PR DESCRIPTION
In the beginning the example is wrong. (: 