### PR TITLE
Alias *test-stream* to *standard-output*

### DIFF
--- a/vars.lisp
+++ b/vars.lisp
@@ -1,7 +1,7 @@
 (in-package :lisp-unit2)
 (cl-interpol:enable-interpol-syntax)
 
-(defvar *test-stream* *standard-output*)
+(defvar *test-stream* (make-synonym-stream '*standard-output*))
 (defvar *test-log-stream* *test-stream*)
 (defvar *unit-test* nil
   "The currently executing unit test (bound in %run-test, ie every test


### PR DESCRIPTION
# Currently `*TEST-STREAM*` is bound to the value `*STANDARD-OUTPUT*` had when

the form was evaluated, most likely when the system was loaded. An
example of how this breaks is when supressing the output of
quickload. Ej. (ql:quickload :lisp-unit2 :silent t)

For further context: http://lisptips.com/post/127524780849/when-a-synonym-stream-is-useful
