### PR TITLE
Export symbols relative to newly defined assertions.

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -19,6 +19,9 @@
      :assert-warning :assert-no-warning
      :assert-signal :assert-no-signal
      :assert-typep
+     :assert-string= :assert-string-equal :assert-string/=
+     :assert-string-not-equal :assert-char= :assert-char-equal
+     :assert-char/= :assert-char-not-equal :assert= :assert/=
      ;; floating point
      :*measure* :*epsilon* :*significant-figures*
      :default-epsilon :sumsq :sump :norm


### PR DESCRIPTION
As report [in this comment](https://github.com/AccelerationNet/lisp-unit2/pull/13#issuecomment-1247638086).

@bobbysmith007 could you please merge it and make a new release? Thanks.