### PR TITLE
Fix SBCL warning.

### DIFF
--- a/lisp-unit2.asd
+++ b/lisp-unit2.asd
@@ -22,8 +22,8 @@
    (:file "interop"))
   :depends-on (:alexandria :cl-interpol :iterate :symbol-munger))
 
-(defsystem :lisp-unit2-test
-  :description "Tests for lisp-unit2 "
+(defsystem :lisp-unit2/tests
+  :description "Tests for lisp-unit2."
   :version "0.9.4"
   :author "Russ Tyndall <russ@acceleration.net>, Acceleration.net,
            Thomas M. Hermann <thomas.m.hermann@odonata-research.com>"


### PR DESCRIPTION
WARNING: Please only define "lisp-unit2" and secondary systems with a name starting with "lisp-unit2/" (e.g. "lisp-unit2/test") in that file.