### PR TITLE
test: fix (asdf:test-system "lisp-unit2")

### DIFF
--- a/lisp-unit2.asd
+++ b/lisp-unit2.asd
@@ -39,7 +39,7 @@
   :depends-on (:lisp-unit2))
 
 (defmethod asdf:perform ((o asdf:test-op) (c (eql (find-system :lisp-unit2))))
-  (asdf:load-system :lisp-unit2-test)
+  (asdf:load-system :lisp-unit2/tests)
   (let ((*package* (find-package :lisp-unit2-tests)))
     (eval (read-from-string
            "(lisp-unit2:run-tests


### PR DESCRIPTION
Wrong ~package~ system name in the perform test-op method.